### PR TITLE
docs: add team member profiles to project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 **Team Members:**
 - Vásquez Villalobos, Elverth Jair **U202213070**
 - Huaman Hinostroza, Milenio **U20211C245**
+- aAsmad Padilla, Fatima **U20221B490**
 
 
 
@@ -115,6 +116,54 @@
 ## 1.1. Startup Profile
 ### 1.1.1. Descripción de la Startup
 ### 1.1.2. Perfiles de integrantes del equipo
+
+---
+
+#### **Fatima Andrea Asmad Padilla – Ingeniería de Software – U20221B490**  
+<img src="https://github.com/user-attachments/assets/e5bb3149-5856-49e3-aa0b-297cedcfe94c" alt="Fatima Asmad" height="200"/>
+
+Mi perfil se caracteriza por la responsabilidad, disciplina y compromiso en cada tarea que realizo, buscando siempre dar lo mejor de mí en cualquier proyecto o actividad asignada. Actualmente curso el sexto ciclo de la carrera de Ingeniería de Software, lo cual me ha permitido adquirir una base sólida en distintas áreas del desarrollo tecnológico.
+
+
+---
+
+#### **XXXXX – Ingeniería de Software – XXXXX**  
+<img src="XXXX" alt="XXX" height="200"/>
+
+XXXXXX
+
+
+---
+
+#### **XXXXX – Ingeniería de Software – XXXXX**  
+<img src="XXXX" alt="XXX" height="200"/>
+
+XXXXXX
+
+---
+
+#### **XXXXX – Ingeniería de Software – XXXXX**  
+<img src="XXXX" alt="XXX" height="200"/>
+
+XXXXXX
+
+
+---
+
+#### **XXXXX – Ingeniería de Software – XXXXX**  
+<img src="XXXX" alt="XXX" height="200"/>
+
+XXXXXX
+
+---
+
+#### **XXXXX – Ingeniería de Software – XXXXX**  
+<img src="XXXX" alt="XXX" height="200"/>
+
+XXXXXX
+
+
+---
 ## 1.2. Solution Profile
 ## 1.2.1 Antecedentes y problemática
 ### 1.2.2 Lean UX Process.


### PR DESCRIPTION
Este commit agrega los perfiles de los integrantes del equipo a la documentación del proyecto. Cada perfil incluye información clave sobre la experiencia, habilidades y roles de los miembros del equipo, con el fin de proporcionar contexto y claridad sobre la estructura y responsabilidades dentro del proyecto.

Estos perfiles serán útiles para cualquier parte interesada que desee conocer mejor el equipo detrás de FOCUST, así como para mejorar la colaboración y el entendimiento mutuo entre los miembros del equipo.